### PR TITLE
v0.3.2

### DIFF
--- a/EditorJS/Parsers/Blocks/BlockParserContext.cs
+++ b/EditorJS/Parsers/Blocks/BlockParserContext.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
+using OrchardCore.Media;
 
 namespace Etch.OrchardCore.Blocks.EditorJS.Parsers.Blocks
 {
@@ -11,6 +12,7 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers.Blocks
         public ContentItem ContentItem { get; set; }
         public HttpContext HttpContext { get; set; }
         public ILiquidTemplateManager LiquidTemplateManager { get; set; }
+        public IMediaFileStore MediaFileStore { get; set; }
         public IShapeFactory ShapeFactory { get; set; }
     }
 }

--- a/EditorJS/Parsers/Blocks/ImageParser.cs
+++ b/EditorJS/Parsers/Blocks/ImageParser.cs
@@ -13,9 +13,21 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers.Blocks
                 {
                     Caption = block.Get("caption"),
                     Stretched = block.Get("stretched", false),
-                    Url = block.Get("url")
+                    Url = GetMediaUrl(context, block)
                 }
             );
+        }
+
+        private string GetMediaUrl(BlockParserContext context, Block block)
+        {
+            var mediaPath = block.Get("mediaPath");
+
+            if (string.IsNullOrEmpty(mediaPath))
+            {
+                return block.Get("url");
+            }
+
+            return context.MediaFileStore.MapPathToPublicUrl(mediaPath);
         }
     }
 }

--- a/EditorJS/Parsers/BlocksParser.cs
+++ b/EditorJS/Parsers/BlocksParser.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
+using OrchardCore.Media;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -37,17 +38,19 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly ILogger<BlocksParser> _logger;
+        private readonly IMediaFileStore _mediaFileStore;
         private readonly IShapeFactory _shapeFactory;
 
         #endregion
 
         #region Constructor
 
-        public BlocksParser(IHttpContextAccessor httpContextAccessor, ILiquidTemplateManager liquidTemplateManager, ILogger<BlocksParser> logger, IShapeFactory shapeFactory)
+        public BlocksParser(IHttpContextAccessor httpContextAccessor, ILiquidTemplateManager liquidTemplateManager, ILogger<BlocksParser> logger, IMediaFileStore mediaFileStore, IShapeFactory shapeFactory)
         {
             _httpContextAccessor = httpContextAccessor;
             _liquidTemplateManager = liquidTemplateManager;
             _logger = logger;
+            _mediaFileStore = mediaFileStore;
             _shapeFactory = shapeFactory;
         }
 
@@ -62,6 +65,7 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers
                 ContentItem = field.ContentItem,
                 HttpContext = _httpContextAccessor.HttpContext,
                 LiquidTemplateManager = _liquidTemplateManager,
+                MediaFileStore = _mediaFileStore,
                 ShapeFactory = _shapeFactory
             }, field.Data);
         }
@@ -73,6 +77,7 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers
                 ContentItem = part.ContentItem,
                 HttpContext = _httpContextAccessor.HttpContext,
                 LiquidTemplateManager = _liquidTemplateManager,
+                MediaFileStore = _mediaFileStore,
                 ShapeFactory = _shapeFactory
             }, part.Data);
         }

--- a/Etch.OrchardCore.Blocks.csproj
+++ b/Etch.OrchardCore.Blocks.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.1-rc2</Version>
+    <Version>0.3.2-rc2</Version>
     <PackageId>Etch.OrchardCore.Blocks</PackageId>
     <Title>Editor.js</Title>
     <Authors>Etch UK</Authors>

--- a/Etch.OrchardCore.Blocks.csproj
+++ b/Etch.OrchardCore.Blocks.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Media.Abstractions" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-13450" />
   </ItemGroup>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content Management",
     Description = "Blocks module enables content items to have a block based editor.",
     Name = "Blocks",
-    Version = "0.3.1",
+    Version = "0.3.2",
     Website = "https://etchuk.com"
 )]
 

--- a/ViewModels/Blocks/ImageBlockViewModel.cs
+++ b/ViewModels/Blocks/ImageBlockViewModel.cs
@@ -3,6 +3,7 @@
     public class ImageBlockViewModel
     {
         public string Caption { get; set; }
+        public string MediaPath { get; set; }
         public bool Stretched { get; set; }
         public string Url { get; set; }
 

--- a/Views/Block-Heading.cshtml
+++ b/Views/Block-Heading.cshtml
@@ -1,5 +1,8 @@
-﻿@{
+﻿@inject OrchardCore.Liquid.ISlugService SlugService
+
+@{
     TagBuilder tag = Tag(Model, $"h{Model.Level.ToString()}");
+    tag.Attributes["id"] = SlugService.Slugify(Model.Text);
 }
 
 @tag.RenderStartTag()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.blocks",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Orchard Core module providing WYSIWYG editor via Editor.js.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Couple of minor updates

- Add `id` to heading block HTML using slugged heading text
- Remove possibility of broken images on image block when moving content to different tenants/environments