### PR TITLE
Always return shape on block field/part but limit to "Detail"

### DIFF
--- a/Drivers/BlockBodyPartDisplay.cs
+++ b/Drivers/BlockBodyPartDisplay.cs
@@ -28,11 +28,6 @@ namespace Etch.OrchardCore.Blocks.Drivers
 
         public override async Task<IDisplayResult> DisplayAsync(BlockBodyPart part, BuildPartDisplayContext context)
         {
-            if (context.DisplayType != "Detail")
-            {
-                return null;
-            }
-
             var blocks = await _blocksParser.RenderAsync(part);
 
             return Initialize<DisplayBlockBodyPartViewModel>("BlockBodyPart", model =>
@@ -41,7 +36,7 @@ namespace Etch.OrchardCore.Blocks.Drivers
                 model.TypePartDefinition = context.TypePartDefinition;
                 model.Blocks = blocks;
             })
-            .Location("Content");
+            .Location("Detail", "Content:5");
         }
 
         public override IDisplayResult Edit(BlockBodyPart part, BuildPartEditorContext context)

--- a/Drivers/BlockFieldDriver.cs
+++ b/Drivers/BlockFieldDriver.cs
@@ -28,11 +28,6 @@ namespace Etch.OrchardCore.Blocks.Drivers
 
         public override async Task<IDisplayResult> DisplayAsync(BlockField field, BuildFieldDisplayContext fieldDisplayContext)
         {
-            if (fieldDisplayContext.DisplayType != "Detail")
-            {
-                return null;
-            }
-
             var blocks = await _blocksParser.RenderAsync(field);
 
             return Initialize<DisplayBlockFieldViewModel>(GetDisplayShapeType(fieldDisplayContext), model =>
@@ -43,7 +38,7 @@ namespace Etch.OrchardCore.Blocks.Drivers
                 model.Html = field.Html;
                 model.Blocks = blocks;
             })
-            .Location("Content");
+            .Location("Detail", "Content:5");
         }
 
         public override IDisplayResult Edit(BlockField field, BuildFieldEditorContext context)


### PR DESCRIPTION
Currently the block field/part won't return a shape when the display type isn't "Detail". This restricts the ability to display the contents of a block field/part on a different display type. Resolution is to always return a shape but only specify a location for the "Detail" display type. This way the developers can use the `placement.json` to render the shape on different display types.