### PR TITLE
Add liquid filter for building blocks display from JSON string

### DIFF
--- a/EditorJS/Parsers/BlocksParser.cs
+++ b/EditorJS/Parsers/BlocksParser.cs
@@ -6,6 +6,7 @@ using Etch.OrchardCore.Blocks.Parsers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using OrchardCore.ContentManagement;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
 using OrchardCore.Media;
@@ -80,6 +81,18 @@ namespace Etch.OrchardCore.Blocks.EditorJS.Parsers
                 MediaFileStore = _mediaFileStore,
                 ShapeFactory = _shapeFactory
             }, part.Data);
+        }
+
+        public async Task<IList<dynamic>> RenderAsync(string data, ContentItem contentItem)
+        {
+            return await RenderAsync(new BlockParserContext
+            {
+                ContentItem = contentItem,
+                HttpContext = _httpContextAccessor.HttpContext,
+                LiquidTemplateManager = _liquidTemplateManager,
+                MediaFileStore = _mediaFileStore,
+                ShapeFactory = _shapeFactory
+            }, data);
         }
 
         #endregion

--- a/Etch.OrchardCore.Blocks.csproj
+++ b/Etch.OrchardCore.Blocks.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <PackageId>Etch.OrchardCore.Blocks</PackageId>
     <Title>Editor.js</Title>
     <Authors>Etch UK</Authors>

--- a/Filters/BlocksBuildDisplayFilter.cs
+++ b/Filters/BlocksBuildDisplayFilter.cs
@@ -1,0 +1,43 @@
+﻿using Etch.OrchardCore.Blocks.EditorJS.Parsers.Blocks;
+using Etch.OrchardCore.Blocks.Parsers;
+using Fluid;
+using Fluid.Values;
+using Newtonsoft.Json.Linq;
+using OrchardCore.ContentManagement;
+using OrchardCore.Liquid;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Blocks.Filters
+{
+    public class BlocksBuildDisplayFilter : ILiquidFilter
+    {
+        private readonly IBlocksParser _blocksParser;
+
+        public BlocksBuildDisplayFilter(IBlocksParser blocksParser) => _blocksParser = blocksParser;
+
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
+        {
+            var data = input.ToStringValue();
+            ContentItem contentItem = null;
+
+            if (arguments.Names.Contains("contentItem"))
+            {
+                var obj = arguments["contentItem"].ToObjectValue();
+
+                if (!(obj is ContentItem))
+                {
+                    contentItem = null;
+
+                    if (obj is JObject jObject)
+                    {
+                        contentItem = jObject.ToObject<ContentItem>();
+                    }
+                }
+            }
+
+            return FluidValue.Create(await _blocksParser.RenderAsync(data, contentItem), context.Options);
+        }
+    }
+}

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content Management",
     Description = "Blocks module enables content items to have a block based editor.",
     Name = "Blocks",
-    Version = "1.1.2",
+    Version = "1.2.0",
     Website = "https://etchuk.com"
 )]
 

--- a/Parsers/IBlocksParser.cs
+++ b/Parsers/IBlocksParser.cs
@@ -1,5 +1,6 @@
 ﻿using Etch.OrchardCore.Blocks.Fields;
 using Etch.OrchardCore.Blocks.Models;
+using OrchardCore.ContentManagement;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -9,5 +10,6 @@ namespace Etch.OrchardCore.Blocks.Parsers
     {
         Task<IList<dynamic>> RenderAsync(BlockField field);
         Task<IList<dynamic>> RenderAsync(BlockBodyPart part);
+        Task<IList<dynamic>> RenderAsync(string data, ContentItem contentItem);
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Etch.OrchardCore.Blocks.Drivers;
 using Etch.OrchardCore.Blocks.Fields;
+using Etch.OrchardCore.Blocks.Filters;
 using Etch.OrchardCore.Blocks.Models;
 using Etch.OrchardCore.Blocks.Parsers;
 using Etch.OrchardCore.Blocks.Services;
@@ -14,6 +15,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
+using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using System;
 
@@ -46,6 +48,8 @@ namespace Etch.OrchardCore.Blocks
             services.AddScoped<IContentSearchResultsProvider, DefaultContentSearchResultsProvider>();
 
             services.AddScoped<IDataMigration, Migrations>();
+
+            services.AddLiquidFilter<BlocksBuildDisplayFilter>("blocks_build_display");
 
             services.Configure<TemplateOptions>(o =>
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.blocks",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "description": "Orchard Core module providing WYSIWYG editor via Editor.js.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Added a new liquid filter (`blocks_build_display`) that can be passed the `Data` value from a field/part and return a collection of shapes that can be rendered. Below is an example:

```
{% assign blocks = Model.Content.Character.Foo.Data | blocks_build_display: contentItem: Model.ContentItem %}

{% for block in blocks %}
    {{ block | shape_render }}
{% endfor %}
```