### PR TITLE
Standardise quote html

### DIFF
--- a/Views/Block-Quote.cshtml
+++ b/Views/Block-Quote.cshtml
@@ -1,12 +1,23 @@
 ﻿@{ 
-    var cssClass = Model.Alignment == "center" ? "blockquote blockquote--centered" : "blockquote";
+    var cssClasses = "styled-quote";
+    if (Model.Alignment == "center")
+    {
+        cssClasses += " text--align-center";
+    } 
 }
 
-<blockquote class="@cssClass">
-    <p>@Html.Raw(Model.Text)</p>
+@* Per the spec, blockquote should only contain direct quote content *@
+@* https://www.w3.org/TR/html5-author/the-blockquote-element.html *@
+
+<figure class="@cssClasses">
+    <blockquote class="styled-quote__copy">
+        <p>@Html.Raw(Model.Text)</p>
+    </blockquote>
 
     @if (Model.HasCaption)
     {
-        <footer>@Html.Raw(Model.Caption)</footer>
+        <figcaption class="styled-quote__source">
+            @Html.Raw(Model.Caption)
+        </figcaption>
     }
-</blockquote>
+</figure>


### PR DESCRIPTION
To bring our multiple quote outputs into one standardised default output, which meets the HTML spec. As part of this, blockquote's default styles are being simplified, and styled-quote is being created to house any complex styling requirements that might arise rather than putting a lot of stuff into the tag based CSS. Adjacent commits will be made to both Widgets and ThemeBoilerplate to match this new expectation.